### PR TITLE
Panel superior con botones y terreno cuadrado

### DIFF
--- a/terreno.py
+++ b/terreno.py
@@ -7,15 +7,13 @@ def _clamp(valor, minimo=0, maximo=255):
     return max(minimo, min(maximo, valor))
 
 # Configuración básica
-ANCHO, ALTO = 800, 600
+ANCHO = 600                     # Área de terreno cuadrada
 ALTO_PANEL = 80
+ALTO = ALTO_PANEL + ANCHO       # Mantiene el terreno como un cuadrado
 TAM_CELDA = 20
 
-# Colores base para cada tipo de terreno. Se utilizan como punto de partida
-# para generar variaciones que den un aspecto menos plano al mapa.
-COLOR_SUELO   = (90, 180, 90)     # Verde hierba
-COLOR_PARED   = (120, 120, 130)   # Piedra
-COLOR_HUECO   = (5, 5, 20)        # Vacío oscuro
+# Colores base
+COLOR_SUELO   = (50, 50, 50)     # Gris oscuro y plano
 COLOR_PANEL   = (200, 200, 200)
 COLOR_TEXTO   = (20, 20, 20)
 
@@ -41,27 +39,16 @@ class Terreno:
             self.mapa.append(fila)
 
     def _color_tile(self, bloque, x, y):
-        """Devuelve un color con variaciones y gradientes según la posición."""
+        """Devuelve un color con variaciones oscuras para cada bloque."""
         rnd = random.Random(x * 1000 + y * 100 + ord(bloque[0]))
         if bloque == "SUELO":
-            # Variar el tono de verde y agregar un gradiente vertical.
-            grad = int(40 * y / self.alto_tiles)
-            r = _clamp(COLOR_SUELO[0] + rnd.randint(-20, 20))
-            g = _clamp(COLOR_SUELO[1] + grad + rnd.randint(-30, 30))
-            b = _clamp(COLOR_SUELO[2] + rnd.randint(-20, 20))
-            return (r, g, b)
+            return COLOR_SUELO
         elif bloque == "PARED":
-            # La piedra se oscurece ligeramente con la profundidad.
-            brillo = int(30 * (self.alto_tiles - y) / self.alto_tiles)
-            offset = rnd.randint(-15, 15) + brillo
-            return tuple(_clamp(c + offset) for c in COLOR_PARED)
+            base = (40, 40, 110)  # Azul oscuro
+            return tuple(_clamp(base[i] + rnd.randint(-20, 20)) for i in range(3))
         else:  # HUECO
-            # Tonos azulados que se aclaran levemente en profundidad.
-            azul = int(50 * y / self.alto_tiles)
-            r = _clamp(COLOR_HUECO[0] + rnd.randint(-10, 10))
-            g = _clamp(COLOR_HUECO[1] + rnd.randint(-10, 10))
-            b = _clamp(COLOR_HUECO[2] + azul + rnd.randint(-10, 10))
-            return (r, g, b)
+            base = (70, 20, 90)  # Morado oscuro
+            return tuple(_clamp(base[i] + rnd.randint(-20, 20)) for i in range(3))
 
     def dibujar(self, surface, cam_x=0, cam_y=0):
         for y, fila in enumerate(self.mapa):
@@ -78,7 +65,7 @@ class Jugador:
     def __init__(self, x, y, tamaño=TAM_CELDA - 4, velocidad=4):
         self.rect = pygame.Rect(x, y, tamaño, tamaño)
         self.velocidad = velocidad
-        self.color = (200, 50, 50)
+        self.color = (60, 20, 120)
 
     def _bloque_en(self, px, py, terreno):
         tile_x = int(px // TAM_CELDA)
@@ -125,14 +112,32 @@ class Jugador:
         pygame.draw.rect(surface, self.color, self.rect.move(cam_x, cam_y))
 
 
-def dibujar_panel(surface, densidad):
+class Boton:
+    def __init__(self, rect, texto, accion):
+        self.rect = pygame.Rect(rect)
+        self.texto = texto
+        self.accion = accion
+
+    def manejar_evento(self, evento):
+        if evento.type == pygame.MOUSEBUTTONDOWN and evento.button == 1:
+            if self.rect.collidepoint(evento.pos):
+                self.accion()
+
+    def dibujar(self, surface):
+        pygame.draw.rect(surface, (230, 230, 230), self.rect)
+        pygame.draw.rect(surface, (50, 50, 50), self.rect, 2)
+        fuente = pygame.font.SysFont(None, 24)
+        texto = fuente.render(self.texto, True, COLOR_TEXTO)
+        surface.blit(texto, texto.get_rect(center=self.rect.center))
+
+
+def dibujar_panel(surface, botones, densidad):
     pygame.draw.rect(surface, COLOR_PANEL, (0, 0, ANCHO, ALTO_PANEL))
-    fuente = pygame.font.SysFont(None, 30)
-    texto = fuente.render(
-        f"[Panel] densidad: {densidad:.2f}  |  +/- para ajustar, R para regenerar",
-        True, COLOR_TEXTO
-    )
-    surface.blit(texto, (10, 25))
+    for boton in botones:
+        boton.dibujar(surface)
+    fuente = pygame.font.SysFont(None, 24)
+    texto = fuente.render(f"Densidad: {densidad:.2f}", True, COLOR_TEXTO)
+    surface.blit(texto, (10, ALTO_PANEL - 30))
 
 
 def posicion_inicial(terreno):
@@ -149,10 +154,9 @@ def main():
     pantalla = pygame.display.set_mode((ANCHO, ALTO), pygame.RESIZABLE)
     pygame.display.set_caption("Generador de Terreno 2D")
     reloj = pygame.time.Clock()
-    fuente = pygame.font.SysFont(None, 24)  # Carga una fuente para el panel
 
     ancho_tiles = ANCHO // TAM_CELDA
-    alto_tiles = (ALTO - ALTO_PANEL) // TAM_CELDA
+    alto_tiles = ancho_tiles
     densidad = 0.1
 
     terreno = Terreno(ancho_tiles, alto_tiles, densidad)
@@ -170,25 +174,42 @@ def main():
         cam_x = min(0, max(min_cam_x, cam_x))
         cam_y = min(0, max(min_cam_y, cam_y))
 
+    def regenerar():
+        terreno.generar()
+        jugador.rect.topleft = posicion_inicial(terreno)
+
+    def densidad_mas():
+        nonlocal densidad
+        densidad = min(densidad + 0.05, 1.0)
+        terreno.densidad = densidad
+        regenerar()
+
+    def densidad_menos():
+        nonlocal densidad
+        densidad = max(densidad - 0.05, 0.0)
+        terreno.densidad = densidad
+        regenerar()
+
+    botones = [
+        Boton((10, 20, 40, 40), "-", densidad_menos),
+        Boton((60, 20, 40, 40), "+", densidad_mas),
+        Boton((120, 20, 120, 40), "Regenerar", regenerar),
+    ]
+
     corriendo = True
     while corriendo:
         for evento in pygame.event.get():
+            for boton in botones:
+                boton.manejar_evento(evento)
             if evento.type == pygame.QUIT:
                 corriendo = False
             elif evento.type == pygame.KEYDOWN:
-                if evento.key == pygame.K_r:          # Regenerar
-                    terreno.generar()
-                    jugador.rect.topleft = posicion_inicial(terreno)
+                if evento.key == pygame.K_r:
+                    regenerar()
                 elif evento.key == pygame.K_PLUS or evento.key == pygame.K_EQUALS:
-                    densidad = min(densidad + 0.05, 1.0)
-                    terreno.densidad = densidad
-                    terreno.generar()
-                    jugador.rect.topleft = posicion_inicial(terreno)
+                    densidad_mas()
                 elif evento.key == pygame.K_MINUS:
-                    densidad = max(densidad - 0.05, 0.0)
-                    terreno.densidad = densidad
-                    terreno.generar()
-                    jugador.rect.topleft = posicion_inicial(terreno)
+                    densidad_menos()
             elif evento.type == pygame.MOUSEBUTTONDOWN and evento.button == 3:
                 arrastrando = True
                 ultimo_mouse = evento.pos
@@ -203,10 +224,12 @@ def main():
                 ultimo_mouse = (mx, my)
                 limitar_camara()
             elif evento.type == pygame.VIDEORESIZE:
-                ANCHO, ALTO = evento.w, evento.h
+                dimension = min(evento.w, evento.h - ALTO_PANEL)
+                ANCHO = dimension
+                ALTO = ALTO_PANEL + dimension
                 pantalla = pygame.display.set_mode((ANCHO, ALTO), pygame.RESIZABLE)
                 ancho_tiles = ANCHO // TAM_CELDA
-                alto_tiles = (ALTO - ALTO_PANEL) // TAM_CELDA
+                alto_tiles = ancho_tiles
                 terreno = Terreno(ancho_tiles, alto_tiles, densidad)
                 jugador.rect.topleft = posicion_inicial(terreno)
                 limitar_camara()
@@ -215,7 +238,7 @@ def main():
         jugador.mover(teclas, terreno)
 
         pantalla.fill((0, 0, 0))
-        dibujar_panel(pantalla, densidad)
+        dibujar_panel(pantalla, botones, densidad)
         terreno.dibujar(pantalla, cam_x, cam_y)
         jugador.dibujar(pantalla, cam_x, cam_y)
 


### PR DESCRIPTION
## Resumen
- Crea un panel superior con botones para regenerar el mapa y ajustar la densidad.
- Mantiene el área del terreno cuadrada y ajusta la cámara tras redimensionar la ventana.
- Actualiza la paleta de colores: suelo gris oscuro y obstáculos en azules/morados.

## Testing
- `python -m py_compile terreno.py`
- `SDL_VIDEODRIVER=dummy timeout 5s python terreno.py`

------
https://chatgpt.com/codex/tasks/task_e_6896a68988c0833195f9034d3840f909