### PR TITLE
Add optional seed for terrain generation

### DIFF
--- a/juego.py
+++ b/juego.py
@@ -1,5 +1,7 @@
 """Punto de entrada del juego y clase principal."""
 
+import random
+
 import pygame
 
 import constantes as const
@@ -75,7 +77,9 @@ class Juego:
         self.cam_x = min(0, max(min_cam_x, self.cam_x))
         self.cam_y = min(0, max(min_cam_y, self.cam_y))
 
-    def regenerar(self):
+    def regenerar(self, semilla=None):
+        if semilla is not None:
+            random.seed(semilla)
         self.terreno.generar()
         self.jugador.rect.topleft = self.terreno.posicion_inicial()
 

--- a/terreno.py
+++ b/terreno.py
@@ -21,6 +21,7 @@ class Terreno:
         densidad=0.1,
         densidad_bosque=0.1,
         num_rios=1,
+        semilla=None,
     ):
         self.ancho_tiles = ancho_tiles
         self.alto_tiles = alto_tiles
@@ -29,6 +30,8 @@ class Terreno:
         self.num_rios = num_rios
         self.mapa = []
         self.colisiones = []
+        if semilla is not None:
+            random.seed(semilla)
         self.generar()
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- allow `Terreno` to accept an optional `semilla` and seed `random` when provided
- let `Juego.regenerar` pass an optional seed and reset RNG accordingly

## Testing
- `python -m py_compile terreno.py juego.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897ee8170e483319f69ef190bf4dafa