### PR TITLE
feat: export terrain data to JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Simulación
+
+## Exportar datos del terreno
+
+La clase `Terreno` permite guardar el estado del mapa y los caminos
+calculados en un archivo JSON:
+
+```python
+from terreno import Terreno
+
+terreno = Terreno(10, 10)
+camino = terreno.calcular_camino((0, 0), (5, 5))
+terreno.exportar_json("terreno.json")
+```
+
+El archivo generado contiene el mapa, la matriz de colisiones y una lista
+de todas las rutas calculadas, de modo que pueda ser reutilizado por otros
+módulos.

--- a/terreno.py
+++ b/terreno.py
@@ -1,5 +1,6 @@
 """Generación y representación del terreno del juego."""
 
+import json
 import random
 import pygame
 
@@ -30,6 +31,7 @@ class Terreno:
         self.num_rios = num_rios
         self.mapa = []
         self.colisiones = []
+        self.rutas = []
         if semilla is not None:
             random.seed(semilla)
         self.generar()
@@ -40,6 +42,7 @@ class Terreno:
     def generar(self):
         self.mapa = []
         self.colisiones = [[False] * self.ancho_tiles for _ in range(self.alto_tiles)]
+        self.rutas = []
         for y in range(self.alto_tiles):
             fila = []
             for x in range(self.ancho_tiles):
@@ -254,6 +257,7 @@ class Terreno:
                     actual = came_from[actual]
                     camino.append(actual)
                 camino.reverse()
+                self.rutas.append(camino)
                 return camino
 
             x, y = actual
@@ -273,4 +277,14 @@ class Terreno:
                         heappush(abiertos, (f_score, vecino))
 
         return None
+
+    def exportar_json(self, ruta):
+        """Guarda el estado del terreno en un archivo JSON."""
+        datos = {
+            "mapa": self.mapa,
+            "colisiones": self.colisiones,
+            "rutas": [[list(celda) for celda in ruta] for ruta in self.rutas],
+        }
+        with open(ruta, "w", encoding="utf-8") as archivo:
+            json.dump(datos, archivo, ensure_ascii=False, indent=2)
 


### PR DESCRIPTION
## Summary
- allow `Terreno` to record generated paths and export map data as JSON
- document JSON export usage in README

## Testing
- `python - <<'PY'
from terreno import Terreno
import json, os, tempfile

t = Terreno(5,5,densidad=0, densidad_bosque=0, num_rios=0, semilla=1)
t.calcular_camino((0,0),(3,3))
with tempfile.NamedTemporaryFile('w+', delete=False, suffix='.json') as tmp:
    path = tmp.name

t.exportar_json(path)
with open(path, 'r', encoding='utf-8') as f:
    data = json.load(f)
print('mapa' in data, 'colisiones' in data, 'rutas' in data)
print('rutas registradas:', len(data['rutas']))
os.remove(path)
PY`

------
https://chatgpt.com/codex/tasks/task_e_6897f2888e088331a5804841a467152d