### PR TITLE
Add CLI terrain generation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,15 @@ terreno.exportar_json("terreno.json")
 El archivo generado contiene el mapa, la matriz de colisiones y una lista
 de todas las rutas calculadas, de modo que pueda ser reutilizado por otros
 módulos.
+
+## Generar terreno desde la línea de comandos
+
+El script `generar_terreno.py` permite crear un mapa sin necesidad de
+escribir código adicional. Los parámetros requeridos son el ancho, el alto y
+una semilla opcional para la generación:
+
+```bash
+python generar_terreno.py 20 15 42
+```
+
+El resultado se guarda en `terreno.json` en el directorio actual.

--- a/generar_terreno.py
+++ b/generar_terreno.py
@@ -1,0 +1,23 @@
+"""Genera un terreno desde la línea de comandos."""
+
+import argparse
+from terreno import Terreno
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Genera un terreno y lo exporta a un archivo JSON"
+    )
+    parser.add_argument("ancho", type=int, help="Ancho del terreno en tiles")
+    parser.add_argument("alto", type=int, help="Alto del terreno en tiles")
+    parser.add_argument(
+        "semilla", type=int, nargs="?", default=None, help="Semilla para la generación"
+    )
+    args = parser.parse_args()
+
+    terreno = Terreno(args.ancho, args.alto, semilla=args.semilla)
+    terreno.exportar_json("terreno.json")
+    print("Terreno exportado a terreno.json")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `generar_terreno.py` to create and export a terrain map as JSON from the command line
- document how to use the new script in the README

## Testing
- `python generar_terreno.py 5 5 1`


------
https://chatgpt.com/codex/tasks/task_e_6897f395b72c8331b6d0f16098eb2d2f