### PR TITLE
Add helper to build armies from configuration

### DIFF
--- a/batalla/ejercito.py
+++ b/batalla/ejercito.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
-from .unidad import Unidad
+from .unidad import (
+    Unidad,
+    Infanteria,
+    Arqueria,
+    Caballeria,
+    Defensa,
+    Soporte,
+)
 
 
 class Ejercito:
@@ -39,3 +46,41 @@ class Ejercito:
                     objetivo.eliminar_unidad(defensor)
             else:
                 raise ValueError("Objetivo no soportado")
+
+
+def crear_ejercito(config):
+    """Crea un :class:`Ejercito` a partir de una configuración.
+
+    Parameters
+    ----------
+    config:
+        Lista de diccionarios con dos claves: ``tipo`` y ``cantidad``. El
+        ``tipo`` debe ser el nombre de la clase de unidad como ``"Infanteria"`` y
+        ``cantidad`` la cantidad de unidades de ese tipo que se desean crear.
+
+    Returns
+    -------
+    Ejercito
+        Objeto de ejército poblado con las unidades especificadas.
+    """
+
+    mapa_unidades = {
+        "Infanteria": Infanteria,
+        "Arqueria": Arqueria,
+        "Caballeria": Caballeria,
+        "Defensa": Defensa,
+        "Soporte": Soporte,
+    }
+
+    ejercito = Ejercito()
+
+    for elemento in config:
+        tipo = elemento.get("tipo")
+        cantidad = elemento.get("cantidad", 0)
+        clase_unidad = mapa_unidades.get(tipo)
+        if clase_unidad is None:
+            raise ValueError(f"Tipo de unidad desconocido: {tipo}")
+        for _ in range(cantidad):
+            ejercito.agregar_unidad(clase_unidad())
+
+    return ejercito


### PR DESCRIPTION
## Summary
- add `crear_ejercito` factory to assemble armies from a configuration list
- map unit names to their classes and populate `Ejercito`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897f89e131c83319ef0c984c46eed5e