### PR TITLE
Add JSON export for armies

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,34 @@ El archivo generado contiene el mapa, la matriz de colisiones y una lista
 de todas las rutas calculadas, de modo que pueda ser reutilizado por otros
 módulos.
 
-## Generar terreno desde la línea de comandos
+## Exportar datos del ejército
 
-El script `generar_terreno.py` permite crear un mapa sin necesidad de
-escribir código adicional. Los parámetros requeridos son el ancho, el alto y
-una semilla opcional para la generación:
+La clase `Ejercito` permite guardar la información de sus unidades en un
+archivo JSON:
+
+```python
+from batalla.ejercito import crear_ejercito
+
+config = [{"tipo": "Infanteria", "cantidad": 2}]
+ejercito = crear_ejercito(config)
+ejercito.exportar_json("ejercito.json")
+```
+
+El archivo generado contiene una lista de unidades con sus atributos básicos
+e identificadores únicos.
+
+## Generar terreno y ejército desde la línea de comandos
+
+El script `generar_terreno.py` permite crear un mapa y un ejército de prueba
+sin necesidad de escribir código adicional. Los parámetros requeridos son el
+ancho, el alto y una semilla opcional para la generación:
 
 ```bash
 python generar_terreno.py 20 15 42
 ```
 
-El resultado se guarda en `terreno.json` en el directorio actual.
+El resultado se guarda en `terreno.json` y `ejercito.json` en el directorio
+actual.
 
 ## Identificadores de unidades
 

--- a/batalla/ejercito.py
+++ b/batalla/ejercito.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 from .unidad import (
     Unidad,
     Infanteria,
@@ -46,6 +48,30 @@ class Ejercito:
                     objetivo.eliminar_unidad(defensor)
             else:
                 raise ValueError("Objetivo no soportado")
+
+    def exportar_json(self, ruta):
+        """Guarda la lista de unidades en un archivo JSON.
+
+        Parameters
+        ----------
+        ruta: str
+            Ruta del archivo donde se almacenará la información.
+        """
+
+        datos = [
+            {
+                "id": str(u.id),
+                "tipo": type(u).__name__,
+                "salud": u.salud,
+                "ataque": u.ataque,
+                "defensa": u.defensa,
+                "velocidad": u.velocidad,
+                "alcance": u.alcance,
+            }
+            for u in self.unidades
+        ]
+        with open(ruta, "w", encoding="utf-8") as archivo:
+            json.dump(datos, archivo, ensure_ascii=False, indent=2)
 
 
 def crear_ejercito(config):

--- a/generar_terreno.py
+++ b/generar_terreno.py
@@ -1,11 +1,12 @@
-"""Genera un terreno desde la línea de comandos."""
+"""Genera un terreno y un ejército desde la línea de comandos."""
 
 import argparse
 from terreno import Terreno
+from batalla.facciones import EjercitoMagia
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Genera un terreno y lo exporta a un archivo JSON"
+        description="Genera un terreno y un ejército y los exporta a archivos JSON"
     )
     parser.add_argument("ancho", type=int, help="Ancho del terreno en tiles")
     parser.add_argument("alto", type=int, help="Alto del terreno en tiles")
@@ -16,7 +17,10 @@ def main():
 
     terreno = Terreno(args.ancho, args.alto, semilla=args.semilla)
     terreno.exportar_json("terreno.json")
+    ejercito = EjercitoMagia()
+    ejercito.exportar_json("ejercito.json")
     print("Terreno exportado a terreno.json")
+    print("Ejército exportado a ejercito.json")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `Ejercito.exportar_json` to serialize unit stats and ids
- extend CLI generator to export a sample army via the new method
- document army export support in README

## Testing
- `python generar_terreno.py 5 5 1`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689800dc1614833183d0e37fcceaf349