### PR TITLE
Mostrar tooltip de unidades

### DIFF
--- a/juego.py
+++ b/juego.py
@@ -7,7 +7,7 @@ import pygame
 import constantes as const
 from terreno import Terreno
 from jugador import Jugador
-from ui import Boton, Selector, dibujar_panel
+from ui import Boton, Selector, dibujar_panel, mostrar_tooltip
 from batalla.campo import CampoBatalla
 from batalla.facciones import EjercitoMagia, EjercitoAngeles, EjercitoDemonios
 from batalla.carga import leer_ejercito
@@ -182,16 +182,21 @@ class Juego:
             self.campo.colocar_unidad(unidad, x, y)
 
     def _dibujar_unidades(self):
+        mx, my = pygame.mouse.get_pos()
+        mx -= self.offset_x
+        my -= self.offset_y
+        unidad_hover = None
         for unidad in self.campo.unidades():
             x, y = self.campo.posicion(unidad)
             sx = x * const.TAM_CELDA + self.cam_x
             sy = const.ALTO_PANEL + y * const.TAM_CELDA + self.cam_y
+            rect = pygame.Rect(sx, sy, const.TAM_CELDA, const.TAM_CELDA)
             color = (255, 0, 0) if unidad in self.ejercito_a.unidades else (0, 0, 255)
-            pygame.draw.rect(
-                self.superficie_juego,
-                color,
-                (sx, sy, const.TAM_CELDA, const.TAM_CELDA),
-            )
+            pygame.draw.rect(self.superficie_juego, color, rect)
+            if rect.collidepoint((mx, my)):
+                unidad_hover = unidad
+        if unidad_hover:
+            mostrar_tooltip(self.superficie_juego, unidad_hover, (mx, my))
 
     def mostrar_preparacion(self):
         self.terreno.dibujar(self.superficie_juego, self.cam_x, self.cam_y)

--- a/ui.py
+++ b/ui.py
@@ -57,3 +57,41 @@ def dibujar_panel(surface, botones, densidad, num_rios, densidad_bosque):
     texto = fuente.render(f"Celda: {const.TAM_CELDA}", True, const.COLOR_TEXTO)
     surface.blit(texto, (520, const.ALTO_PANEL - 30))
 
+
+def mostrar_tooltip(surface, unidad, pos):
+    """Renderiza un cuadro con información básica de ``unidad``.
+
+    Parameters
+    ----------
+    surface:
+        Superficie sobre la que se dibuja el tooltip.
+    unidad:
+        Objeto que posee atributos ``salud``, ``ataque``, ``defensa``,
+        ``velocidad`` y ``alcance``.
+    pos:
+        Tupla ``(x, y)`` indicando la posición donde mostrar el tooltip.
+    """
+
+    fuente = pygame.font.SysFont(None, 20)
+    lineas = [
+        f"Salud: {unidad.salud}",
+        f"Ataque: {unidad.ataque}",
+        f"Defensa: {unidad.defensa}",
+        f"Velocidad: {unidad.velocidad}",
+        f"Alcance: {unidad.alcance}",
+    ]
+    textos = [fuente.render(t, True, const.COLOR_TEXTO) for t in lineas]
+    ancho = max(t.get_width() for t in textos) + 10
+    alto = sum(t.get_height() for t in textos) + 10
+    x, y = pos
+    x = min(x + 10, surface.get_width() - ancho)
+    y = min(y + 10, surface.get_height() - alto)
+    rect = pygame.Rect(x, y, ancho, alto)
+    pygame.draw.rect(surface, (230, 230, 230), rect)
+    pygame.draw.rect(surface, (50, 50, 50), rect, 1)
+    offset_y = y + 5
+    for texto in textos:
+        surface.blit(texto, (x + 5, offset_y))
+        offset_y += texto.get_height()
+
+


### PR DESCRIPTION
## Summary
- Añade función `mostrar_tooltip` para renderizar información de las unidades.
- Muestra tooltip al pasar el mouse sobre unidades en el campo de batalla.

## Testing
- `python -m py_compile juego.py ui.py`


------
https://chatgpt.com/codex/tasks/task_e_689806bf70508331a6161b5dc27c682b