### PR TITLE
Add minimap rendering for preparation and battle

### DIFF
--- a/juego.py
+++ b/juego.py
@@ -7,7 +7,7 @@ import pygame
 import constantes as const
 from terreno import Terreno
 from jugador import Jugador
-from ui import Boton, Selector, dibujar_panel, mostrar_tooltip
+from ui import Boton, Selector, dibujar_panel, mostrar_tooltip, dibujar_minimapa
 from batalla.campo import CampoBatalla
 from batalla.facciones import EjercitoMagia, EjercitoAngeles, EjercitoDemonios
 from batalla.carga import leer_ejercito
@@ -208,8 +208,17 @@ class Juego:
 
     def mostrar_preparacion(self):
         self.terreno.dibujar(self.superficie_juego, self.cam_x, self.cam_y)
+        posiciones = []
         if self.campo:
             self._dibujar_unidades()
+            for unidad in self.campo.unidades():
+                x, y = self.campo.posicion(unidad)
+                color = (
+                    (255, 0, 0)
+                    if unidad in self.ejercito_a.unidades
+                    else (0, 0, 255)
+                )
+                posiciones.append((x, y, color))
         # Resaltar las rutas calculadas para cada ejército
         colores = {"A": (255, 0, 0), "B": (0, 0, 255)}
         for ejercito, rutas in self.terreno.rutas.items():
@@ -220,6 +229,7 @@ class Juego:
                     sy = const.ALTO_PANEL + y * const.TAM_CELDA + self.cam_y
                     rect = pygame.Rect(sx, sy, const.TAM_CELDA, const.TAM_CELDA)
                     pygame.draw.rect(self.superficie_juego, color, rect, 2)
+        dibujar_minimapa(self.superficie_juego, self.terreno, posiciones)
 
     # ------------------------------------------------------------------
     # Bucle principal
@@ -286,7 +296,17 @@ class Juego:
         else:
             self.terreno.dibujar(self.superficie_juego, self.cam_x, self.cam_y)
             if self.estado == "combate" and self.campo:
+                posiciones = []
                 self._dibujar_unidades()
+                for unidad in self.campo.unidades():
+                    x, y = self.campo.posicion(unidad)
+                    color = (
+                        (255, 0, 0)
+                        if unidad in self.ejercito_a.unidades
+                        else (0, 0, 255)
+                    )
+                    posiciones.append((x, y, color))
+                dibujar_minimapa(self.superficie_juego, self.terreno, posiciones)
             else:
                 self.jugador.dibujar(self.superficie_juego, self.cam_x, self.cam_y)
         self.pantalla.fill((0, 0, 0))

--- a/ui.py
+++ b/ui.py
@@ -95,3 +95,43 @@ def mostrar_tooltip(surface, unidad, pos):
         offset_y += texto.get_height()
 
 
+def dibujar_minimapa(surface, terreno, posiciones=()):
+    """Dibuja una vista reducida del terreno y las unidades.
+
+    ``surface`` es la superficie de destino, ``terreno`` el mapa completo y
+    ``posiciones`` una secuencia opcional de tuplas ``(x, y, color)`` donde
+    ``x`` e ``y`` son coordenadas de tiles.
+    """
+
+    tamaño = 150
+    margen = 10
+    rect = pygame.Rect(
+        const.ANCHO - tamaño - margen,
+        const.ALTO_PANEL + margen,
+        tamaño,
+        tamaño,
+    )
+    pygame.draw.rect(surface, (30, 30, 30), rect)
+    tile_w = rect.width / terreno.ancho_tiles
+    tile_h = rect.height / terreno.alto_tiles
+    for y, fila in enumerate(terreno.mapa):
+        for x, bloque in enumerate(fila):
+            color = terreno._color_tile(bloque, x, y)
+            celda = pygame.Rect(
+                rect.x + int(x * tile_w),
+                rect.y + int(y * tile_h),
+                int(tile_w) + 1,
+                int(tile_h) + 1,
+            )
+            pygame.draw.rect(surface, color, celda)
+    for x, y, color in posiciones:
+        px = rect.x + int(x * tile_w)
+        py = rect.y + int(y * tile_h)
+        pygame.draw.rect(
+            surface,
+            color,
+            (px, py, max(2, int(tile_w)), max(2, int(tile_h))),
+        )
+    pygame.draw.rect(surface, (255, 255, 255), rect, 1)
+
+


### PR DESCRIPTION
## Summary
- render scaled-down terrain and unit positions via `dibujar_minimapa`
- show minimap during preparation and combat phases

## Testing
- `python -m py_compile ui.py juego.py`


------
https://chatgpt.com/codex/tasks/task_e_68980c337bdc8331b85fed54d9e5a5e7