### PR TITLE
Guardar captura inicial de batalla

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ python generar_terreno.py 20 15 42
 El resultado se guarda en `terreno.json` y `ejercito.json` en el directorio
 actual.
 
+## Captura de pantalla inicial de batalla
+
+Al confirmar una batalla desde `juego.py`, se guarda automáticamente la
+superficie actual en una imagen llamada `captura_inicial.png` ubicada en el
+directorio donde se ejecuta el juego.
+
 ## Identificadores de unidades
 
 Cada instancia de ``Unidad`` y sus subclases genera automáticamente un

--- a/juego.py
+++ b/juego.py
@@ -165,6 +165,9 @@ class Juego:
         self.boton_batalla.accion = self.comenzar_combate
 
     def comenzar_combate(self):
+        # Guardar captura de la superficie actual antes de iniciar la batalla.
+        # El archivo se guarda en el directorio de ejecución.
+        pygame.image.save(self.superficie_juego, "captura_inicial.png")
         self.estado = "combate"
         self.boton_batalla.texto = "Batalla"
         self.boton_batalla.accion = self.iniciar_batalla


### PR DESCRIPTION
## Summary
- Captura la superficie del juego al confirmar una batalla y la guarda como `captura_inicial.png`.
- Documenta en el README que la imagen se almacena en el directorio de ejecución.

## Testing
- `python -m py_compile juego.py`


------
https://chatgpt.com/codex/tasks/task_e_68980e954b78833189b8bd7a5a3aa218