### PR TITLE
Track per-unit damage and highlight MVP in battle report

### DIFF
--- a/batalla/campo.py
+++ b/batalla/campo.py
@@ -28,7 +28,12 @@ class CampoBatalla:
         ]
         self._posiciones: Dict[Unidad, Tuple[int, int]] = {}
         self._salud_max: Dict[Unidad, int] = {}
-        self._estadisticas = {"turno_actual": 0, "daño_total": 0, "curacion_total": 0}
+        self._estadisticas = {
+            "turno_actual": 0,
+            "daño_total": 0,
+            "curacion_total": 0,
+            "daño_por_unidad": {},
+        }
 
     # ------------------------------------------------------------------
     # Gestión de unidades
@@ -154,6 +159,9 @@ class CampoBatalla:
             if dist <= unidad.alcance:
                 daño = objetivo.recibir_daño(unidad.ataque)
                 self._estadisticas["daño_total"] += daño
+                self._estadisticas["daño_por_unidad"][unidad] = (
+                    self._estadisticas["daño_por_unidad"].get(unidad, 0) + daño
+                )
                 acciones.append(
                     {
                         "tipo": "atacar",
@@ -205,5 +213,6 @@ class CampoBatalla:
 
     def obtener_estadisticas(self) -> dict:
         """Devuelve un resumen de la simulación realizada."""
-
-        return dict(self._estadisticas)
+        stats = dict(self._estadisticas)
+        stats["daño_por_unidad"] = dict(self._estadisticas["daño_por_unidad"])
+        return stats

--- a/juego.py
+++ b/juego.py
@@ -392,6 +392,8 @@ class Juego:
                             ganadores.append("Ejército A")
                         if self.ejercito_b.unidades:
                             ganadores.append("Ejército B")
+                        daños = estadisticas.get("daño_por_unidad", {})
+                        unidad_mvp = max(daños, key=daños.get) if daños else None
                         with open("reporte_batalla.txt", "w", encoding="utf-8") as reporte:
                             reporte.write(
                                 "Ganadores: "
@@ -401,11 +403,19 @@ class Juego:
                             reporte.write(
                                 f"Turnos totales: {estadisticas.get('turno_actual', 0)}\n\n"
                             )
-                            reporte.write("Resumen por unidad:\n")
-                            for unidad in self.campo.unidades():
+                            if unidad_mvp:
                                 reporte.write(
-                                    f"- {unidad.__class__.__name__} (ID {unidad.id}) - Salud: {unidad.salud}\n"
+                                    "MVP: "
+                                    f"{unidad_mvp.__class__.__name__} (ID {unidad_mvp.id}) - Daño infligido: {daños[unidad_mvp]}\n\n"
                                 )
+                            reporte.write("Resumen por unidad:\n")
+                            for unidad, daño in daños.items():
+                                linea = (
+                                    f"- {unidad.__class__.__name__} (ID {unidad.id}) - Salud: {unidad.salud} - Daño infligido: {daño}"
+                                )
+                                if unidad is unidad_mvp:
+                                    linea += " (MVP)"
+                                reporte.write(linea + "\n")
 
                         self.estado = "exploracion"
                         self.boton_batalla.texto = "Batalla"
@@ -446,7 +456,10 @@ class Juego:
             self.pantalla.fill((0, 0, 0))
             y = 20
             for linea in lineas:
-                texto = fuente.render(linea.strip(), True, (255, 255, 255))
+                color = (255, 255, 255)
+                if linea.startswith("MVP") or "(MVP)" in linea:
+                    color = (255, 215, 0)
+                texto = fuente.render(linea.strip(), True, color)
                 self.pantalla.blit(texto, (20, y))
                 y += 30
             instrucciones = fuente.render(


### PR DESCRIPTION
## Summary
- Track damage inflicted by each unit and record it in battle statistics.
- Generate battle report with per-unit damage and identify the highest-damage unit as MVP.
- Highlight MVP details in the report display.

## Testing
- `python -m py_compile batalla/campo.py juego.py`


------
https://chatgpt.com/codex/tasks/task_e_68981d23e8308331b6f6370ddf75a19f