### PR TITLE
Registrar acciones de batalla para replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,31 @@ print(soldado.id)
 
 Este identificador es útil para referenciar unidades específicas durante
 la simulación o el registro de eventos.
+
+## Registro de batalla
+
+Al finalizar un combate se genera el archivo `replay.json` con el historial
+completo de la simulación. El contenido es una lista ordenada de turnos; cada
+elemento contiene el número de turno y las acciones realizadas:
+
+```json
+[
+  {
+    "turno": 1,
+    "acciones": [
+      {
+        "tipo": "mover",
+        "unidad": {"id": 1, "tipo": "Infanteria"},
+        "origen": [0, 0],
+        "destino": [1, 0]
+      }
+    ]
+  }
+]
+```
+
+Las acciones incluyen el tipo (`mover`, `atacar` o `curar`), las posiciones
+de origen y destino cuando corresponda y las unidades implicadas
+identificadas por su `id` y clase. Otro módulo puede leer este archivo y
+recrear la batalla paso a paso siguiendo el orden de los turnos y sus
+acciones.

--- a/juego.py
+++ b/juego.py
@@ -417,6 +417,8 @@ class Juego:
                                     linea += " (MVP)"
                                 reporte.write(linea + "\n")
 
+                        self.campo.exportar_replay("replay.json")
+
                         self.estado = "exploracion"
                         self.boton_batalla.texto = "Batalla"
                         self.boton_batalla.accion = self.iniciar_batalla


### PR DESCRIPTION
## Summary
- Acumula las acciones de cada turno en `CampoBatalla` y permite exportarlas como `replay.json` con datos de unidades
- Genera el archivo de replay al terminar la batalla en `juego.py`
- Documenta el formato del archivo de replay para reproducir la simulación paso a paso

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
from terreno import Terreno
from batalla.campo import CampoBatalla
from batalla.ejercito import Ejercito
from batalla.unidad import Infanteria
terreno = Terreno(3, 3, densidad=0, densidad_bosque=0, num_rios=0)
campo = CampoBatalla(terreno)
A = Ejercito(); B = Ejercito()
a1 = Infanteria(); b1 = Infanteria()
campo.colocar_unidad(a1, 0, 0); A.agregar_unidad(a1)
campo.colocar_unidad(b1, 2, 2); B.agregar_unidad(b1)
for _ in range(2):
    campo.simular_turno(A, B)
campo.exportar_replay('replay_test.json')
print('replay_guardado', len(campo._replay))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68981e2016e4833181b9da866fe43821