### PR TITLE
Amplía tamaño inicial del mapa

### DIFF
--- a/constantes.py
+++ b/constantes.py
@@ -12,6 +12,9 @@ ALTO = ALTO_PANEL + ANCHO
 # Tamaño de cada celda de terreno (puede modificarse en tiempo de ejecución)
 TAM_CELDA = int(20 * 1.15)
 
+# Factor de escala para el tamaño inicial del mapa
+FACTOR_MAPA = 2
+
 # Colores utilizados en distintos elementos del juego
 COLOR_SUELO = (50, 50, 50)
 COLOR_PANEL = (200, 200, 200)

--- a/juego.py
+++ b/juego.py
@@ -20,8 +20,9 @@ class Juego:
         pygame.display.set_caption("Generador de Terreno 2D")
         self.reloj = pygame.time.Clock()
 
-        self.ancho_tiles = const.ANCHO // const.TAM_CELDA
-        self.alto_tiles = self.ancho_tiles
+        tamaño_base = const.ANCHO // const.TAM_CELDA
+        self.ancho_tiles = tamaño_base * const.FACTOR_MAPA
+        self.alto_tiles = tamaño_base * const.FACTOR_MAPA
         self.densidad = 0.1
         self.densidad_bosque = 0.1
         self.num_rios = 1


### PR DESCRIPTION
## Summary
- Permite ajustar el tamaño inicial del mapa mediante `FACTOR_MAPA`
- Doble del área jugable al crear el terreno

## Testing
- `python -m py_compile constantes.py juego.py`
- `python - <<'PY'
import os
os.environ['SDL_VIDEODRIVER']='dummy'
import juego
j = juego.Juego()
print('ancho_tiles', j.ancho_tiles)
print('alto_tiles', j.alto_tiles)
PY`


------
https://chatgpt.com/codex/tasks/task_e_6899570f6f9483318bc4c97124f3ad83