### PR TITLE
Implement A* pathfinding with route cache

### DIFF
--- a/tests/test_campo.py
+++ b/tests/test_campo.py
@@ -42,7 +42,30 @@ def test_simular_turno_en_fases():
     campo, ej_a, ej_b, herido, enemigo = crear_campo_simple()
     acciones = campo.simular_turno(ej_a, ej_b)
     tipos = [a["tipo"] for a in acciones]
-    assert tipos == ["curar", "atacar", "mover", "mover"]
-    assert campo.posicion(herido) == (2, 0)
+    # Solo el enemigo se mueve: el aliado está bloqueado por otra unidad
+    assert tipos == ["curar", "atacar", "mover"]
+    assert campo.posicion(herido) == (1, 0)
     assert campo.posicion(enemigo) == (4, 0)
     assert enemigo.salud == 93  # 100 - (12 - 5)
+
+
+def test_movimiento_evita_obstaculos():
+    """Las unidades deben rodear obstáculos utilizando la búsqueda de camino."""
+    terreno = Terreno(3, 3, densidad=0.0, densidad_bosque=0.0, num_rios=0, semilla=1)
+    # Bloquea la celda intermedia para forzar un desvío
+    terreno.mapa[0][1] = "PARED"
+    terreno.colisiones[0][1] = True
+    campo = CampoBatalla(terreno)
+    ej_a = Ejercito()
+    ej_b = Ejercito()
+    u1 = Infanteria()
+    u2 = Infanteria()
+    ej_a.agregar_unidad(u1)
+    ej_b.agregar_unidad(u2)
+    campo.colocar_unidad(u1, 0, 0)
+    campo.colocar_unidad(u2, 2, 0)
+
+    campo.simular_turno(ej_a, ej_b)
+
+    assert campo.posicion(u1) == (0, 1)
+    assert campo.posicion(u2) == (2, 1)


### PR DESCRIPTION
## Summary
- Add A* pathfinding in `CampoBatalla` considering terrain and unit obstacles
- Cache computed routes and update movement phase to follow full paths
- Test movement around obstacles and adjust existing phase test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68995edd41988331a0c0f2fd48ef6b7b